### PR TITLE
Use individual compile directives for Google play services

### DIFF
--- a/shared_assets/build.gradle
+++ b/shared_assets/build.gradle
@@ -53,55 +53,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services:6.5.87'
+    compile 'com.google.android.gms:play-services-location:6.5.87'
+    compile 'com.google.android.gms:play-services-wearable:6.5.87'
     compile 'com.android.support:support-v13:+'
-}
-
-def toCamelCase(String string) {
-    String result = ""
-    string.findAll("[^\\W]+") { String word ->
-        result += word.capitalize()
-    }
-    return result
-}
-
-afterEvaluate { project ->
-    Configuration runtimeConfiguration = project.configurations.getByName('compile')
-    ResolutionResult resolution = runtimeConfiguration.incoming.resolutionResult
-    ModuleVersionIdentifier module = resolution.getAllComponents().find { it.moduleVersion.name.equals("play-services") }.moduleVersion
-
-    String prepareTaskName = "prepare${toCamelCase("${module.group} ${module.name} ${module.version}")}Library"
-    File playServiceRootFolder = project.tasks.find { it.name.equals(prepareTaskName) }.explodedDir
-
-    Task stripPlayServices = project.tasks.create(name: 'stripPlayServices', group: "Strip") {
-        inputs.files new File(playServiceRootFolder, "classes.jar")
-        outputs.dir playServiceRootFolder
-        description 'Strip useless packages from Google Play Services library to avoid reaching dex limit'
-
-        doLast {
-            copy {
-                from(file(new File(playServiceRootFolder, "classes.jar")))
-                into(file(playServiceRootFolder))
-                rename { fileName ->
-                    fileName = "classes_orig.jar"
-                }
-            }
-            tasks.create(name: "stripPlayServices" + module.version, type: Jar) {
-                destinationDir = playServiceRootFolder
-                archiveName = "classes.jar"
-                from(zipTree(new File(playServiceRootFolder, "classes_orig.jar"))) {
-                    exclude "com/google/ads/**"
-                    exclude "com/google/android/gms/analytics/**"
-                    exclude "com/google/android/gms/maps/**"
-                    exclude "com/google/android/gms/games/**"
-                    exclude "com/google/android/gms/ads/**"
-                }
-            }.execute()
-            delete file(new File(playServiceRootFolder, "classes_orig.jar"))
-        }
-    }
-
-    project.tasks.findAll { it.name.startsWith('prepare') && it.name.endsWith('Dependencies') }.each { Task task ->
-        task.dependsOn stripPlayServices
-    }
 }


### PR DESCRIPTION
From version 6.5 of Google play services you can selectively depend on portions of the API, this allows you to stay under the methods limit easier.