### PR TITLE
better Youtube detection

### DIFF
--- a/src/main/java/com/klinker/android/twitter/adapters/TweetPagerAdapter.java
+++ b/src/main/java/com/klinker/android/twitter/adapters/TweetPagerAdapter.java
@@ -117,7 +117,7 @@ public class TweetPagerAdapter extends FragmentPagerAdapter {
 
         if (links.length > 0 && !links[0].equals("")) {
             for (String s : links) {
-                if (s.contains("youtu")) {
+                if (s.contains("youtube.") || s.contains("youtu.be")) {
                     video = s;
                     youtube = true;
                     break;


### PR DESCRIPTION
Fix a problem when a link contains the word "youtu" and it is not a youtube video, such as this tweet: https://twitter.com/MKBHD/status/668103691975675904

Talon will try to add a youtube page that gives an error.