### PR TITLE
Removed unnecessary check for retweeting protected account

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/fragments/TweetFragment.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/fragments/TweetFragment.java
@@ -1321,17 +1321,6 @@ public class TweetFragment extends Fragment {
                     ((Activity) context).runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-
-                            // you can't retweet a protected account
-                            if (status.getUser().isProtected()) {
-                                retweetButton.setOnClickListener(new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View v) {
-                                        Toast.makeText(context, getString(R.string.protected_account), Toast.LENGTH_SHORT).show();
-                                    }
-                                });
-                            }
-
                             retweetCount.setText(" " + retCount);
 
                             if (retweetButton instanceof ImageButton) {


### PR DESCRIPTION
I think it was handled in d04257c2b995e43ca28c0c788e5456fcea2e9ebc ; with this check one wasn't able to retweet a tweet which protected user retweeted.