### PR TITLE
Fix saving images in PhotoViewerActivity

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoViewerActivity.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoViewerActivity.java
@@ -21,6 +21,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.MediaStore;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -28,17 +29,17 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
-import android.widget.ListView;
 import android.widget.Toast;
 
 import com.klinker.android.twitter.R;
-import com.klinker.android.twitter.views.HoloEditText;
-import com.klinker.android.twitter.views.HoloTextView;
-import com.klinker.android.twitter.views.NetworkedCacheableImageView;
 import com.klinker.android.twitter.settings.AppSettings;
 import com.klinker.android.twitter.utils.IOUtils;
+import com.klinker.android.twitter.views.NetworkedCacheableImageView;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Random;
@@ -48,12 +49,11 @@ import uk.co.senab.photoview.PhotoViewAttacher;
 
 public class PhotoViewerActivity extends Activity {
 
-    public Context context;
-    public HoloEditText text;
-    public ListView list;
-    public String url;
-    public NetworkedCacheableImageView picture;
-    public HoloTextView download;
+    private static final String LOGGER_TAG = "PhotoViewerActivity";
+
+    private Context context;
+    private String url;
+    private NetworkedCacheableImageView picture;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -62,7 +62,9 @@ public class PhotoViewerActivity extends Activity {
 
         try {
             getWindow().requestFeature(Window.FEATURE_ACTION_BAR_OVERLAY);
-        } catch (Exception e) { }
+        } catch (Exception e) {
+            Log.e(LOGGER_TAG, "", e);
+        }
 
         if (Build.VERSION.SDK_INT > 18) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION | WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
@@ -129,7 +131,7 @@ public class PhotoViewerActivity extends Activity {
         }
     }
 
-    public void downloadImage() {
+    private void downloadImage() {
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -182,6 +184,7 @@ public class PhotoViewerActivity extends Activity {
 
                     mNotificationManager.notify(6, mBuilder.build());
                 } catch (Exception e) {
+                    Log.e(LOGGER_TAG, "Exception while saving photo", e);
                     NotificationCompat.Builder mBuilder =
                             new NotificationCompat.Builder(context)
                                     .setSmallIcon(R.drawable.ic_stat_icon)


### PR DESCRIPTION
Apparently, saving images in Talon is broken now because we have target sdk 24, which is more than 22, hence we have to check permissions in runtime (see [api docs](https://developer.android.com/training/permissions/requesting.html)).

So, I added basic check for this permission in this activity, now once you grant the permission saving images will work well. If you approve it and merge it, I'll integrate it in the rest of the places where `saveImage` is called. Also will probably try to extract some common logic for saving images; right now there is a log of duplication.