### PR TITLE
added create channel for service notifications for 8.1 compatibility

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter/activities/compose/Compose.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/compose/Compose.java
@@ -102,6 +102,8 @@ import com.yalantis.ucrop.UCrop;
 import twitter4j.*;
 import uk.co.senab.photoview.PhotoViewAttacher;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public abstract class Compose extends Activity implements
         GoogleApiClient.ConnectionCallbacks,
         GoogleApiClient.OnConnectionFailedListener {
@@ -622,7 +624,7 @@ public abstract class Compose extends Activity implements
         }
 
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setContentTitle(getResources().getString(R.string.tweet_failed))
                         .setContentText(e.getMessage());
@@ -634,7 +636,7 @@ public abstract class Compose extends Activity implements
 
     public void makeFailedNotification(String text) {
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setContentTitle(getResources().getString(R.string.tweet_failed))
                         .setContentText(getResources().getString(R.string.tap_to_retry));
@@ -662,7 +664,7 @@ public abstract class Compose extends Activity implements
 
     public void makeTweetingNotification() {
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setOngoing(true)
                         .setProgress(100, 0, true);
@@ -695,7 +697,7 @@ public abstract class Compose extends Activity implements
             public void run() {
                 try {
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setContentTitle(getResources().getString(R.string.tweet_success))
                                     .setOngoing(false)

--- a/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoFragment.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoFragment.java
@@ -34,6 +34,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Random;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class PhotoFragment extends Fragment {
     
     private Activity activity;
@@ -95,7 +97,7 @@ public class PhotoFragment extends Fragment {
 
                 try {
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(activity)
+                            new NotificationCompat.Builder(activity, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.downloading) + "...")
                                     .setContentTitle(getResources().getString(R.string.app_name))
@@ -130,7 +132,7 @@ public class PhotoFragment extends Fragment {
                     PendingIntent pending = PendingIntent.getActivity(activity, 91, intent, 0);
 
                     mBuilder =
-                            new NotificationCompat.Builder(activity)
+                            new NotificationCompat.Builder(activity, TALON_SERVICE_CHANNEL_ID)
                                     .setContentIntent(pending)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.saved_picture) + "...")
@@ -141,7 +143,7 @@ public class PhotoFragment extends Fragment {
                     mNotificationManager.notify(6, mBuilder.build());
                 } catch (Exception e) {
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(activity)
+                            new NotificationCompat.Builder(activity, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.error) + "...")
                                     .setContentTitle(getResources().getString(R.string.app_name))

--- a/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoViewerActivity.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/photo_viewer/PhotoViewerActivity.java
@@ -52,6 +52,8 @@ import java.util.Random;
 import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 import uk.co.senab.photoview.PhotoViewAttacher;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class PhotoViewerActivity extends Activity {
 
     private static final String LOGGER_TAG = "PhotoViewerActivity";
@@ -156,7 +158,7 @@ public class PhotoViewerActivity extends Activity {
 
                 try {
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.downloading) + "...")
                                     .setContentTitle(getResources().getString(R.string.app_name))
@@ -191,7 +193,7 @@ public class PhotoViewerActivity extends Activity {
                     PendingIntent pending = PendingIntent.getActivity(context, 91, intent, 0);
 
                     mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setContentIntent(pending)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.saved_picture) + "...")
@@ -203,7 +205,7 @@ public class PhotoViewerActivity extends Activity {
                 } catch (Exception e) {
                     Log.e(LOGGER_TAG, "Exception while saving photo", e);
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(getResources().getString(R.string.error) + "...")
                                     .setContentTitle(getResources().getString(R.string.app_name))

--- a/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/TweetPager.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/TweetPager.java
@@ -61,6 +61,8 @@ import java.util.Random;
 
 import twitter4j.Twitter;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class TweetPager extends YouTubeBaseActivity {
 
     private TweetPagerAdapter mSectionsPagerAdapter;
@@ -590,7 +592,7 @@ public class TweetPager extends YouTubeBaseActivity {
 
                         try {
                             NotificationCompat.Builder mBuilder =
-                                    new NotificationCompat.Builder(context)
+                                    new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                             .setSmallIcon(R.drawable.ic_stat_icon)
                                             .setTicker(getResources().getString(R.string.downloading) + "...")
                                             .setContentTitle(getResources().getString(R.string.app_name))
@@ -623,7 +625,7 @@ public class TweetPager extends YouTubeBaseActivity {
                             PendingIntent pending = PendingIntent.getActivity(context, 91, intent, 0);
 
                             mBuilder =
-                                    new NotificationCompat.Builder(context)
+                                    new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                             .setContentIntent(pending)
                                             .setSmallIcon(R.drawable.ic_stat_icon)
                                             .setTicker(getResources().getString(R.string.saved_picture) + "...")
@@ -635,7 +637,7 @@ public class TweetPager extends YouTubeBaseActivity {
                         } catch (Exception e) {
                             e.printStackTrace();
                             NotificationCompat.Builder mBuilder =
-                                    new NotificationCompat.Builder(context)
+                                    new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                             .setSmallIcon(R.drawable.ic_stat_icon)
                                             .setTicker(getResources().getString(R.string.error) + "...")
                                             .setContentTitle(getResources().getString(R.string.app_name))

--- a/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/fragments/VideoFragment.java
+++ b/app/src/main/java/com/klinker/android/twitter/activities/tweet_viewer/fragments/VideoFragment.java
@@ -31,6 +31,8 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class VideoFragment extends Fragment {
 
     public Context context;
@@ -219,7 +221,7 @@ public class VideoFragment extends Fragment {
             public void run() {
                 try {
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(context.getResources().getString(R.string.downloading) + "...")
                                     .setContentTitle(context.getResources().getString(R.string.app_name))
@@ -239,7 +241,7 @@ public class VideoFragment extends Fragment {
                     PendingIntent pending = PendingIntent.getActivity(context, 91, intent, 0);
 
                     mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setContentIntent(pending)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setContentTitle(context.getResources().getString(R.string.app_name))
@@ -250,7 +252,7 @@ public class VideoFragment extends Fragment {
                     e.printStackTrace();
 
                     NotificationCompat.Builder mBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_icon)
                                     .setTicker(context.getResources().getString(R.string.error) + "...")
                                     .setContentTitle(context.getResources().getString(R.string.app_name))

--- a/app/src/main/java/com/klinker/android/twitter/data/App.java
+++ b/app/src/main/java/com/klinker/android/twitter/data/App.java
@@ -17,7 +17,10 @@
 package com.klinker.android.twitter.data;
 
 import android.app.Application;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
 
 import com.klinker.android.twitter.utils.EmojiUtils;
 import com.klinker.android.twitter.utils.text.EmojiInitializer;
@@ -25,6 +28,9 @@ import com.klinker.android.twitter.utils.text.EmojiInitializer;
 import java.io.File;
 
 import uk.co.senab.bitmapcache.BitmapLruCache;
+
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_DESCRIPTION;
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
 
 public class App extends Application {
     private BitmapLruCache mCache;
@@ -35,7 +41,7 @@ public class App extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-
+        initChannel();
         File cacheDir = new File(getCacheDir(), "talon");
         cacheDir.mkdirs();
 
@@ -60,7 +66,13 @@ public class App extends Application {
         }).start();
         EmojiInitializer.INSTANCE.initializeEmojiCompat(this);
     }
+    public void initChannel(){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            nm.createNotificationChannel(new NotificationChannel(TALON_SERVICE_CHANNEL_ID, TALON_SERVICE_CHANNEL_DESCRIPTION, NotificationManager.IMPORTANCE_DEFAULT));
 
+        }
+    }
     public BitmapLruCache getBitmapCache() {
         return mCache;
     }

--- a/app/src/main/java/com/klinker/android/twitter/services/SendQueue.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/SendQueue.java
@@ -39,6 +39,8 @@ import java.util.regex.Matcher;
 
 import twitter4j.Twitter;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 
 public class SendQueue extends Service {
 
@@ -138,7 +140,7 @@ public class SendQueue extends Service {
     public void sendingNotification() {
         // first we will make a notification to let the user know we are tweeting
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setContentTitle(getResources().getString(R.string.sending_tweet))
                                 //.setTicker(getResources().getString(R.string.sending_tweet))
@@ -163,7 +165,7 @@ public class SendQueue extends Service {
     public void makeFailedNotification(String text, AppSettings settings) {
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(this)
+                    new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_failed))
                             .setContentText(getResources().getString(R.string.tap_to_retry));
@@ -195,7 +197,7 @@ public class SendQueue extends Service {
     public void finishedTweetingNotification() {
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(MainActivity.sContext)
+                    new NotificationCompat.Builder(MainActivity.sContext, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_success))
                             .setOngoing(false)

--- a/app/src/main/java/com/klinker/android/twitter/services/SendScheduledTweet.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/SendScheduledTweet.java
@@ -40,6 +40,8 @@ import java.util.regex.Matcher;
 
 import twitter4j.Twitter;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class SendScheduledTweet extends IntentService {
 
     SharedPreferences sharedPrefs;
@@ -129,7 +131,7 @@ public class SendScheduledTweet extends IntentService {
     public void sendingNotification() {
         // first we will make a notification to let the user know we are tweeting
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setContentTitle(getResources().getString(R.string.sending_tweet))
                         .setOngoing(true)
@@ -153,7 +155,7 @@ public class SendScheduledTweet extends IntentService {
     public void makeFailedNotification(String text, AppSettings settings) {
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(this)
+                    new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_failed))
                             .setContentText(getResources().getString(R.string.tap_to_retry));
@@ -185,7 +187,7 @@ public class SendScheduledTweet extends IntentService {
     public void finishedTweetingNotification() {
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(MainActivity.sContext)
+                    new NotificationCompat.Builder(MainActivity.sContext, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_success))
                             .setOngoing(false)

--- a/app/src/main/java/com/klinker/android/twitter/services/SendTweet.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/SendTweet.java
@@ -50,6 +50,8 @@ import java.io.InputStream;
 
 import twitter4j.Twitter;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 
 public class SendTweet extends Service {
 
@@ -308,7 +310,7 @@ public class SendTweet extends Service {
     public void sendingNotification() {
         // first we will make a notification to let the user know we are tweeting
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setContentTitle(getResources().getString(R.string.sending_tweet))
                                 //.setTicker(getResources().getString(R.string.sending_tweet))
@@ -336,7 +338,7 @@ public class SendTweet extends Service {
     public void makeFailedNotification(String text, AppSettings settings) {
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(this)
+                    new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_failed))
                             .setContentText(getResources().getString(R.string.tap_to_retry));
@@ -376,7 +378,7 @@ public class SendTweet extends Service {
 
         try {
             NotificationCompat.Builder mBuilder =
-                    new NotificationCompat.Builder(MainActivity.sContext)
+                    new NotificationCompat.Builder(MainActivity.sContext, TALON_SERVICE_CHANNEL_ID)
                             .setSmallIcon(R.drawable.ic_stat_icon)
                             .setContentTitle(getResources().getString(R.string.tweet_success))
                             .setOngoing(false)

--- a/app/src/main/java/com/klinker/android/twitter/services/TalonPullNotificationService.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/TalonPullNotificationService.java
@@ -69,6 +69,8 @@ import twitter4j.UserStreamListener;
 import uk.co.senab.bitmapcache.BitmapLruCache;
 import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class TalonPullNotificationService extends Service {
 
     public static final int FOREGROUND_SERVICE_ID = 11;
@@ -155,7 +157,7 @@ public class TalonPullNotificationService extends Service {
         }
 
         mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(android.R.color.transparent)
                         .setContentTitle(getResources().getString(R.string.talon_pull) + (multAcc ? " - @" + settings.myScreenName : ""))
                         .setContentText(text)

--- a/app/src/main/java/com/klinker/android/twitter/services/TrimDataService.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/TrimDataService.java
@@ -48,6 +48,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Date;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class TrimDataService extends IntentService {
 
     SharedPreferences sharedPrefs;
@@ -103,7 +105,7 @@ public class TrimDataService extends IntentService {
         Intent goToStore = new Intent(this, RedirectToPlayStore.class);
         PendingIntent storePending = PendingIntent.getActivity(this, 0, goToStore, 0);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID);
         builder.setContentTitle("Talon Version " + version);
         builder.setContentText("Click to update.");
         builder.setLargeIcon(BitmapFactory.decodeResource(getResources(),

--- a/app/src/main/java/com/klinker/android/twitter/services/WidgetRefreshService.java
+++ b/app/src/main/java/com/klinker/android/twitter/services/WidgetRefreshService.java
@@ -40,6 +40,8 @@ import twitter4j.Paging;
 import twitter4j.Status;
 import twitter4j.Twitter;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class WidgetRefreshService  extends IntentService {
 
     SharedPreferences sharedPrefs;
@@ -60,7 +62,7 @@ public class WidgetRefreshService  extends IntentService {
                 0);
 
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, TALON_SERVICE_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_stat_icon)
                         .setTicker(getResources().getString(R.string.refreshing) + "...")
                         .setContentTitle(getResources().getString(R.string.app_name))

--- a/app/src/main/java/com/klinker/android/twitter/settings/AppSettings.java
+++ b/app/src/main/java/com/klinker/android/twitter/settings/AppSettings.java
@@ -196,6 +196,9 @@ public class AppSettings {
     public EmojiStyle emojiStyle;
     public int tweetCharacterCount = 280;
 
+    public static String TALON_SERVICE_CHANNEL_ID = "TALON_SERVICE_ID";
+    public static String TALON_SERVICE_CHANNEL_DESCRIPTION = "Talon Service Channel";
+
     public AppSettings(Context context) {
 
         sharedPrefs = context.getSharedPreferences("com.klinker.android.twitter_world_preferences",

--- a/app/src/main/java/com/klinker/android/twitter/utils/ActivityUtils.java
+++ b/app/src/main/java/com/klinker/android/twitter/utils/ActivityUtils.java
@@ -22,6 +22,8 @@ import twitter4j.*;
 
 import java.util.*;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class ActivityUtils {
 
     private static String TAG = "ActivityUtils";
@@ -150,7 +152,7 @@ public class ActivityUtils {
             return;
         }
 
-        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID);
         mBuilder.setContentTitle(notificationTitle);
         mBuilder.setSmallIcon(R.drawable.ic_stat_icon);
         mBuilder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(),

--- a/app/src/main/java/com/klinker/android/twitter/utils/NotificationUtils.java
+++ b/app/src/main/java/com/klinker/android/twitter/utils/NotificationUtils.java
@@ -69,6 +69,8 @@ import twitter4j.User;
 import uk.co.senab.bitmapcache.BitmapLruCache;
 import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 
+import static com.klinker.android.twitter.settings.AppSettings.TALON_SERVICE_CHANNEL_ID;
+
 public class NotificationUtils {
 
     // Key for the string that's delivered in the action's intent
@@ -137,7 +139,7 @@ public class NotificationUtils {
 
             Intent deleteIntent = new Intent(context, NotificationDeleteReceiverOne.class);
 
-            mBuilder = new NotificationCompat.Builder(context)
+            mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                     .setContentTitle(title[0])
                     .setContentText(TweetLinkUtils.removeColorHtml(shortText, settings))
                     .setSmallIcon(R.drawable.ic_stat_icon)
@@ -666,7 +668,7 @@ public class NotificationUtils {
 
         Intent deleteIntent = new Intent(context, NotificationDeleteReceiverOne.class);
 
-        mBuilder = new NotificationCompat.Builder(context)
+        mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(TweetLinkUtils.removeColorHtml(shortText, settings))
                 .setSmallIcon(smallIcon)
@@ -798,7 +800,7 @@ public class NotificationUtils {
 
         Intent deleteIntent = new Intent(context, NotificationDeleteReceiverTwo.class);
 
-        mBuilder = new NotificationCompat.Builder(context)
+        mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(TweetLinkUtils.removeColorHtml(message, settings))
                 .setSmallIcon(smallIcon)
@@ -922,7 +924,7 @@ public class NotificationUtils {
 
         Intent deleteIntent = new Intent(context, NotificationDeleteReceiverTwo.class);
 
-        mBuilder = new NotificationCompat.Builder(context)
+        mBuilder =  new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(TweetLinkUtils.removeColorHtml(message, settings))
                 .setSmallIcon(smallIcon)
@@ -1148,7 +1150,7 @@ public class NotificationUtils {
 
         Intent deleteIntent = new Intent(context, NotificationDeleteReceiverOne.class);
 
-        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(Html.fromHtml(settings.addonTheme ? smallText.replaceAll("FF8800", settings.accentColor) : smallText))
                 .setSmallIcon(R.drawable.ic_stat_icon)
@@ -1255,7 +1257,7 @@ public class NotificationUtils {
 
             Intent deleteIntent = new Intent(context, NotificationDeleteReceiverOne.class);
 
-            mBuilder = new NotificationCompat.Builder(context)
+            mBuilder = new NotificationCompat.Builder(context, TALON_SERVICE_CHANNEL_ID)
                     .setContentTitle(shortText)
                     .setContentText(longText)
                     .setSmallIcon(R.drawable.ic_stat_icon)


### PR DESCRIPTION
Hi @klinker24 the project was failing on my device that has 8.1 because of notifications, throwing the error:
`Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification`
Fixed it by creating a channel and then add the channel when creating the Notification.

Please let me know what you think.
